### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -1,4 +1,6 @@
 name: Proof HTML
+permissions:
+  contents: read
 on:
   push:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/fantastic-spoon/security/code-scanning/1](https://github.com/AKA-NETWORK/fantastic-spoon/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow likely only needs to read repository contents, we will set `contents: read` as the minimal required permission. This change ensures that the workflow has the least privileges necessary to perform its tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
